### PR TITLE
Add step to auto-bump semver based on the latest commit message

### DIFF
--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -94,18 +94,19 @@ jobs:
         file: ci/concourse-ci/tasks/version-calculator-task.yml
         input_mapping:
           repo: app
-        output_mapping:
-          version: new_app_version
         vars:
           current_version: ((.:app_version.version_number))
+      - load_var: new_version
+        file: version/new_version # output from bump-version task
       - put: deno-app-docker-image
         inputs:
           - docker-image-fresh-build
-          - app
+          - app          
         params: 
           image: docker-image-fresh-build/image.tar
           additional_tags: app/.git/HEAD
-          version: new_app_version/new_version
+          version: ((.:new_version))
+          bump_aliases: true
       # Update the version in the file, push the changes & add changelog ?
       #- task: deno-deploy-docker
       #  file: ci/concourse-ci/tasks/deploy-docker-task.yml

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -105,7 +105,7 @@ jobs:
         params: 
           image: docker-image-fresh-build/image.tar
           additional_tags: app/.git/HEAD
-          version: new_app_version
+          version: new_app_version/new_version
       # Update the version in the file, push the changes & add changelog ?
       #- task: deno-deploy-docker
       #  file: ci/concourse-ci/tasks/deploy-docker-task.yml

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -61,6 +61,8 @@ jobs:
       # - put: gh-status
       #   inputs: [app]
       #   params: {state: pending}
+      - load_var: app_version
+        file: app/version.json
       - task: deno-format-check-and-lint
         file: ci/concourse-ci/tasks/deno-task.yml
         vars: 
@@ -88,13 +90,22 @@ jobs:
           image: docker-image-fresh-build
         vars:            
           build_docker_task_dockerfile_dir_path: "backend"
+      - task: bump-version
+        file: ci/concourse-ci/tasks/version-calculator-task.yml
+        input_mapping:
+          repo: app
+        output_mapping:
+          version: new_app_version        
+        
       - put: deno-app-docker-image
         inputs:
           - docker-image-fresh-build
           - app
         params: 
           image: docker-image-fresh-build/image.tar
-          additional_tags: app/.git/HEAD
+          additional_tags: app/.git/
+          version: new_app_version
+      # Update the version in the file, push the changes & add changelog ?
       #- task: deno-deploy-docker
       #  file: ci/concourse-ci/tasks/deploy-docker-task.yml
       #  input_mapping:

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -95,8 +95,9 @@ jobs:
         input_mapping:
           repo: app
         output_mapping:
-          version: new_app_version        
-        
+          version: new_app_version
+        vars:
+          current_version: ((.:version.version_number))
       - put: deno-app-docker-image
         inputs:
           - docker-image-fresh-build

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -97,7 +97,7 @@ jobs:
         output_mapping:
           version: new_app_version
         vars:
-          current_version: ((.:version.version_number))
+          current_version: ((.:app_version.version_number))
       - put: deno-app-docker-image
         inputs:
           - docker-image-fresh-build

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -62,7 +62,7 @@ jobs:
       #   inputs: [app]
       #   params: {state: pending}
       - load_var: app_version
-        file: app/version.json
+        file: app/backend/version.json
       - task: deno-format-check-and-lint
         file: ci/concourse-ci/tasks/deno-task.yml
         vars: 

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -104,7 +104,7 @@ jobs:
           - app
         params: 
           image: docker-image-fresh-build/image.tar
-          additional_tags: app/.git/
+          additional_tags: app/.git/HEAD
           version: new_app_version
       # Update the version in the file, push the changes & add changelog ?
       #- task: deno-deploy-docker

--- a/concourse-ci/tasks/build-docker-task.yml
+++ b/concourse-ci/tasks/build-docker-task.yml
@@ -15,6 +15,7 @@ outputs:
 
 params: 
   CONTEXT: app-source/((build_docker_task_dockerfile_dir_path))
+  BUILD_ARG_BACKEND_APP_VERSION: app-source/.git/HEAD
 
 run:
   path: build

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -1,0 +1,30 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: 
+    repository: node
+    tag: 18-slim
+
+inputs:
+  - name: repo
+
+outputs:
+  - name: version
+
+run:
+  path: sh
+  args: 
+    - -c
+    - |        
+    COMMMIT_MESSAGE=$(cd repo && git log -1 --format=%B)
+    case "${COMMMIT_MESSAGE}" in 
+      fix/*) NEW_VERSION=$(npx semver -i patch ((current_version)) )
+      feat/*) NEW_VERSION=$(npx semver -i minor ((current_version)) )
+      breaking/*) NEW_VERSION=$(npx semver -i major ((current_version)) )
+      *) NEW_VERSION=$(npx semver -i patch ((current_version)) )    
+    esac
+    echo "${NEW_VERSION}" > version
+
+    

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -17,14 +17,28 @@ run:
   path: sh
   args: 
     - -c
-    - |        
-    COMMMIT_MESSAGE=$(cd repo && git log -1 --format=%B)
-    case "${COMMMIT_MESSAGE}" in 
-      fix/*) NEW_VERSION=$(npx semver -i patch ((current_version)) )
-      feat/*) NEW_VERSION=$(npx semver -i minor ((current_version)) )
-      breaking/*) NEW_VERSION=$(npx semver -i major ((current_version)) )
-      *) NEW_VERSION=$(npx semver -i patch ((current_version)) )    
-    esac
-    echo "${NEW_VERSION}" > version
-
-    
+    - | 
+      apt-get -qq update && apt-get -q install git -y        
+      export COMMIT_MESSAGE=$(cd repo && git log -1 --format=%B)
+      echo "Commit message is ${COMMIT_MESSAGE}"
+      echo "Current version is ((current_version))"      
+      case "${COMMIT_MESSAGE}" in 
+        fix/* ) 
+          NEW_VERSION=$(npx --yes semver -i patch ((current_version)) )
+          echo "Based on commit message, version gets a patch update. ((current_version)) -> ${NEW_VERSION}"
+          ;;
+        feat/* ) 
+          NEW_VERSION=$(npx --yes semver -i minor ((current_version)) )
+          echo "Based on commit message, version gets a minor update. ((current_version)) -> ${NEW_VERSION}"
+          ;;
+        breaking/* ) 
+          NEW_VERSION=$(npx --yes semver -i major ((current_version)) )
+          echo "Based on commit message, version gets a major update. ((current_version)) -> ${NEW_VERSION}"
+          ;;
+        *) 
+          NEW_VERSION=$(npx --yes semver -i patch ((current_version)) )
+          echo "No relevant keyword found in commit, defaulting to patch update. ((current_version)) -> ${NEW_VERSION}"
+          ;;          
+      esac
+      echo "Writing new version to output file"
+      echo "${NEW_VERSION}" > version/new_version


### PR DESCRIPTION
- Calculate semver using https://www.npmjs.com/package/semver and the "version.json" file in dashbits's backend
- Implement simple script for now to calculate version bump (supports only patch, minor and major for now) based on commit message
- Apply that version to the docker image and update version variants accordingly