### PR TITLE
Feat/concourse deployment docker

### DIFF
--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -96,6 +96,7 @@ jobs:
           repo: app
         vars:
           current_version: ((.:app_version))
+          version_file_path: repo/backend/VERSION
       - load_var: new_version
         file: version/new_version # output from bump-version task
       - put: github-repo-app

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -98,7 +98,7 @@ jobs:
           current_version: ((.:app_version))
       - load_var: new_version
         file: version/new_version # output from bump-version task
-      - put: app
+      - put: github-repo-app
         params:
           repository: repo # output from bump-version task
       - put: deno-app-docker-image

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -96,7 +96,7 @@ jobs:
           repo: app
         vars:
           current_version: ((.:app_version))
-          version_file_path: repo/backend/VERSION
+          version_file_path: backend/VERSION
       - load_var: new_version
         file: version/new_version # output from bump-version task
       - put: github-repo-app

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -1,19 +1,19 @@
 ---
-# resource_types:
-# - name: cogito
-#   type: registry-image
-#   check_every: 1h
-#   source:
-#     repository: pix4d/cogito
+resource_types:
+- name: cogito
+  type: registry-image
+  check_every: 1h
+  source:
+    repository: pix4d/cogito
 
 resources:
-  # - name: gh-status
-  #   type: cogito
-  #   check_every: 1h
-  #   source:
-  #     owner: Niceplace
-  #     repo: dashbits
-  #     access_token: ((github.accesstoken))
+  - name: gh-status
+    type: cogito
+    check_every: 1h
+    source:
+      owner: Niceplace
+      repo: dashbits
+      access_token: ((github.accesstoken))
   - name: github-repo-app
     type: git
     source:
@@ -40,55 +40,55 @@ resources:
 
 jobs:
   - name: deno-check
-    # on_success:
-    #   put: gh-status
-    #   inputs: [github-repo-app]
-    #   params: {state: success}
-    # on_failure:
-    #   put: gh-status
-    #   inputs: [github-repo-app]
-    #   params: {state: failure}        
-    # on_error:
-    #   put: gh-status
-    #   inputs: [github-repo-app]
-    #   params: {state: error}
+    on_success:
+      put: gh-status
+      inputs: [github-repo-app]
+      params: {state: success}
+    on_failure:
+      put: gh-status
+      inputs: [github-repo-app]
+      params: {state: failure}        
+    on_error:
+      put: gh-status
+      inputs: [github-repo-app]
+      params: {state: error}
     plan:
       - in_parallel:
         - get: app
           resource: github-repo-app
         - get: ci
           resource: github-repo-ci
-      # - put: gh-status
-      #   inputs: [app]
-      #   params: {state: pending}
-      - load_var: app_version
+      - put: gh-status
+        inputs: [app]
+        params: {state: pending}
+      - task: deno-format-check-and-lint
+        file: ci/concourse-ci/tasks/deno-task.yml
+        vars: 
+          deno_command_and_args: "deno fmt --check app/backend/"
+        input_mapping:
+          app: app
+      - task: deno-unit-tests
+        file: ci/concourse-ci/tasks/deno-task.yml
+        vars:
+          deno_command_and_args: "deno test app/backend/*.test.unit.ts"
+        input_mapping:
+          app: app
+      - task: deno-integration-tests
+        file: ci/concourse-ci/tasks/deno-task.yml
+        vars:            
+          deno_command_and_args: "deno test --allow-read --allow-env app/backend/*.test.integration.ts"
+        input_mapping:
+          app: app      
+      - load_var: app_backend_version_current
         file: app/backend/VERSION
-      # - task: deno-format-check-and-lint
-      #   file: ci/concourse-ci/tasks/deno-task.yml
-      #   vars: 
-      #     deno_task_command_and_args: "deno fmt --check app/backend/"
-      #   input_mapping:
-      #     app: app
-      # - task: deno-unit-tests
-      #   file: ci/concourse-ci/tasks/deno-task.yml
-      #   vars:
-      #     deno_task_command_and_args: "deno test app/backend/*.test.unit.ts"
-      #   input_mapping:
-      #     app: app
-      # - task: deno-integration-tests
-      #   file: ci/concourse-ci/tasks/deno-task.yml
-      #   vars:            
-      #     deno_task_command_and_args: "deno test --allow-read --allow-env app/backend/*.test.integration.ts"
-      #   input_mapping:
-      #     app: app      
       - task: bump-version
         file: ci/concourse-ci/tasks/version-calculator-task.yml
         input_mapping:
           repo: app
         vars:
-          current_version: ((.:app_version))
-          version_file_path: backend/VERSION
-      - load_var: new_version
+          version_calculator_current_version: ((.:app_backend_version_current))
+          version_calculator_version_file_path: backend/VERSION
+      - load_var: app_backend_version_new
         file: version/new_version # output from bump-version task
       - put: github-repo-app
         params:
@@ -101,8 +101,8 @@ jobs:
         output_mapping:
           image: docker-image-fresh-build
         vars:            
-          build_docker_task_dockerfile_dir_path: "backend"
-          build_docker_app_version: ((.:new_version))
+          build_docker_dockerfile_dir_path: "backend"
+          build_docker_app_version: ((.:app_backend_version_new))
       - put: deno-app-docker-image
         inputs:
           - docker-image-fresh-build
@@ -110,19 +110,18 @@ jobs:
         params: 
           image: docker-image-fresh-build/image.tar
           additional_tags: app/.git/HEAD
-          version: ((.:new_version))
-          bump_aliases: true
-      # Update the version in the file, push the changes & add changelog ?
+          version: ((.:app_backend_version_new))
+          bump_aliases: true      
       - task: deno-deploy-dashbits-backend
         privileged: true
         file: ci/concourse-ci/tasks/deploy-docker-task.yml
         input_mapping:
           image: docker-image-fresh-build
         vars:
-          thinkcenter_ssh_config: ((thinkcenter_ssh_config))
-          thinkcenter_ssh_private: ((thinkcenter_ssh_private))
-          thinkcenter_ssh_public: ((thinkcenter_ssh_public))                              
-          deployable_image_name: "registry.thinkcenter.dev/dashbits-backend:((.:new_version))"
-          container_name: dashbits-backend
-          app_url_reverse_proxy: dashbits-backend.thinkcenter.dev
-          app_server_port: "3000"
+          deploy_docker_thinkcenter_ssh_config: ((thinkcenter_ssh_config))
+          deploy_docker_thinkcenter_ssh_private: ((thinkcenter_ssh_private))
+          deploy_docker_thinkcenter_ssh_public: ((thinkcenter_ssh_public))                              
+          deploy_docker_deployable_image_name: "registry.thinkcenter.dev/dashbits-backend:((.:app_backend_version_new))"
+          deploy_docker_container_name: dashbits-backend
+          deploy_docker_app_url_reverse_proxy: dashbits-backend.thinkcenter.dev
+          deploy_docker_app_server_port: "3000"

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -120,8 +120,8 @@ jobs:
         vars:
           thinkcenter_ssh_config: ((thinkcenter_ssh_config))
           thinkcenter_ssh_private: ((thinkcenter_ssh_private))
-          thinkcenter_ssh_public: ((thinkcenter_ssh_public))                    
-          image_version_to_deploy: ((.:new_version))
+          thinkcenter_ssh_public: ((thinkcenter_ssh_public))                              
+          deployable_image_name: "registry.thinkcenter.dev/dashbits-backend:((.:new_version))"
           container_name: dashbits-backend
           app_url_reverse_proxy: dashbits-backend.thinkcenter.dev
           app_server_port: "3000"

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -80,16 +80,7 @@ jobs:
       #   vars:            
       #     deno_task_command_and_args: "deno test --allow-read --allow-env app/backend/*.test.integration.ts"
       #   input_mapping:
-      #     app: app
-      - task: deno-build-docker
-        privileged: true
-        file: ci/concourse-ci/tasks/build-docker-task.yml
-        input_mapping:
-          app-source: app
-        output_mapping:
-          image: docker-image-fresh-build
-        vars:            
-          build_docker_task_dockerfile_dir_path: "backend"
+      #     app: app      
       - task: bump-version
         file: ci/concourse-ci/tasks/version-calculator-task.yml
         input_mapping:
@@ -102,6 +93,16 @@ jobs:
       - put: github-repo-app
         params:
           repository: repo # output from bump-version task
+      - task: deno-build-docker
+        privileged: true
+        file: ci/concourse-ci/tasks/build-docker-task.yml
+        input_mapping:
+          app-source: app
+        output_mapping:
+          image: docker-image-fresh-build
+        vars:            
+          build_docker_task_dockerfile_dir_path: "backend"
+          build_docker_app_version: ((.:new_version))
       - put: deno-app-docker-image
         inputs:
           - docker-image-fresh-build

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -114,6 +114,8 @@ jobs:
         input_mapping:
           image: docker-image-fresh-build
         vars:
-          thinkcenter-ssh-key: ((thinkcenter-ssh-key))
+          thinkcenter-ssh-config: ((thinkcenter-ssh-config))
+          thinkcenter-ssh-private: ((thinkcenter-ssh-private))
+          thinkcenter-ssh-public: ((thinkcenter-ssh-public))
           old_version: ((.:app_version.version_number))
           new_version: ((.:app_version.version_number))

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -124,4 +124,4 @@ jobs:
           image_version_to_deploy: ((.:new_version))
           container_name: dashbits-backend
           app_url_reverse_proxy: dashbits-backend.thinkcenter.dev
-          app_server_port: 3000
+          app_server_port: "3000"

--- a/concourse-ci/pipelines/build-deno-pipeline.yml
+++ b/concourse-ci/pipelines/build-deno-pipeline.yml
@@ -29,14 +29,14 @@ resources:
       username: ((github.accesstoken))
       password: x-oauth-basic
       branch: ((branch_ci))
-  # - name: deno-app-docker-image
-  #   type: registry-image
-  #   icon: docker
-  #   source:
-  #     repository: registry.thinkcenter.dev/dashbits-backend #https://github.com/concourse/registry-image-resource/issues/10#issuecomment-477570948
-  #     ca_certs:
-  #       - ((registry.certificate))
-  #     tag: "latest"
+  - name: deno-app-docker-image
+    type: registry-image
+    icon: docker
+    source:
+      repository: registry.thinkcenter.dev/dashbits-backend #https://github.com/concourse/registry-image-resource/issues/10#issuecomment-477570948
+      ca_certs:
+        - ((registry.certificate))
+      tag: "latest"
 
 jobs:
   - name: deno-check
@@ -62,7 +62,7 @@ jobs:
       #   inputs: [app]
       #   params: {state: pending}
       - load_var: app_version
-        file: app/backend/version.json
+        file: app/backend/VERSION
       # - task: deno-format-check-and-lint
       #   file: ci/concourse-ci/tasks/deno-task.yml
       #   vars: 
@@ -90,32 +90,37 @@ jobs:
           image: docker-image-fresh-build
         vars:            
           build_docker_task_dockerfile_dir_path: "backend"
-      # - task: bump-version
-      #   file: ci/concourse-ci/tasks/version-calculator-task.yml
-      #   input_mapping:
-      #     repo: app
-      #   vars:
-      #     current_version: ((.:app_version.version_number))
-      # - load_var: new_version
-      #   file: version/new_version # output from bump-version task
-      # - put: deno-app-docker-image
-      #   inputs:
-      #     - docker-image-fresh-build
-      #     - app          
-      #   params: 
-      #     image: docker-image-fresh-build/image.tar
-      #     additional_tags: app/.git/HEAD
-      #     version: ((.:new_version))
-      #     bump_aliases: true
+      - task: bump-version
+        file: ci/concourse-ci/tasks/version-calculator-task.yml
+        input_mapping:
+          repo: app
+        vars:
+          current_version: ((.:app_version))
+      - load_var: new_version
+        file: version/new_version # output from bump-version task
+      - put: app
+        params:
+          repository: repo # output from bump-version task
+      - put: deno-app-docker-image
+        inputs:
+          - docker-image-fresh-build
+          - app          
+        params: 
+          image: docker-image-fresh-build/image.tar
+          additional_tags: app/.git/HEAD
+          version: ((.:new_version))
+          bump_aliases: true
       # Update the version in the file, push the changes & add changelog ?
-      - task: deno-deploy-docker
+      - task: deno-deploy-dashbits-backend
         privileged: true
         file: ci/concourse-ci/tasks/deploy-docker-task.yml
         input_mapping:
           image: docker-image-fresh-build
         vars:
-          thinkcenter-ssh-config: ((thinkcenter-ssh-config))
-          thinkcenter-ssh-private: ((thinkcenter-ssh-private))
-          thinkcenter-ssh-public: ((thinkcenter-ssh-public))
-          old_version: ((.:app_version.version_number))
-          new_version: ((.:app_version.version_number))
+          thinkcenter_ssh_config: ((thinkcenter_ssh_config))
+          thinkcenter_ssh_private: ((thinkcenter_ssh_private))
+          thinkcenter_ssh_public: ((thinkcenter_ssh_public))                    
+          image_version_to_deploy: ((.:new_version))
+          container_name: dashbits-backend
+          app_url_reverse_proxy: dashbits-backend.thinkcenter.dev
+          app_server_port: 3000

--- a/concourse-ci/tasks/build-docker-task.yml
+++ b/concourse-ci/tasks/build-docker-task.yml
@@ -14,7 +14,7 @@ outputs:
   - name: image
 
 params: 
-  CONTEXT: app-source/((build_docker_task_dockerfile_dir_path))
+  CONTEXT: app-source/((build_docker_dockerfile_dir_path))
   BUILD_ARG_BACKEND_APP_VERSION: ((build_docker_app_version))
 
 run:

--- a/concourse-ci/tasks/build-docker-task.yml
+++ b/concourse-ci/tasks/build-docker-task.yml
@@ -15,7 +15,7 @@ outputs:
 
 params: 
   CONTEXT: app-source/((build_docker_task_dockerfile_dir_path))
-  BUILD_ARG_BACKEND_APP_VERSION: app-source/.git/HEAD
+  BUILD_ARG_BACKEND_APP_VERSION: ((build_docker_app_version))
 
 run:
   path: build

--- a/concourse-ci/tasks/deno-task.yml
+++ b/concourse-ci/tasks/deno-task.yml
@@ -14,4 +14,4 @@ run:
   path: /bin/bash
   args: 
     - -c
-    - ((deno_task_command_and_args))
+    - ((deno_command_and_args))

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -28,25 +28,26 @@ run:
       ssh-keyscan thinkcenter.dev > $HOME/.ssh/known_hosts      
       echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
-      docker context use remote-thinkcenter      
-      export RUNNING_APP_IMAGE=$(docker ps --format "{{.Image}}" --filter "name=((container_name))" --filter "status=running")
-      if [[ -n "${RUNNING_APP_IMAGE}" ]];
+      docker context use remote-thinkcenter            
+      export EXISTING_APP_CONTAINERS_IDS=$(docker ps --format "{{.ID}}" --filter "name=((container_name))" --filter "status=running")
+      if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]];
       then
-        echo "Stopping and removing containers using ${RUNNING_APP_IMAGE} and deleting the image from the local cache"
-        docker stop ((container_name))
-        docker rm ((container_name))
-        docker rmi ${RUNNING_APP_IMAGE}
+        echo "Stopping and removing containers using ${RUNNING_APP_IMAGE}"
+        docker stop "${EXISTING_APP_CONTAINERS_IDS}"
+        docker rm "${EXISTING_APP_CONTAINERS_IDS}"
       fi
       echo "Loading and tagging ((deployable_image_name))"
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))
       echo "Running ((deployable_image_name)) with name ((container_name))"
-      docker run --name=((container_name)) -d ((deployable_image_name)) \
+      docker run --name=((container_name)) \ 
+        --detach \
         --label "traefik.enable=true" \
         --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)" \
         --label "traefik.http.routers.((container_name)).entrypoints=websecure" \
         --label "traefik.http.routers.((container_name)).tls=true" \
-        --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
+        --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))" \
+        ((deployable_image_name))
 
       
       

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: fhivemind/concourse-dind/
+    repository: fhivemind/concourse-dind
 
 inputs:
   - name: image
@@ -15,20 +15,38 @@ run:
     - -c
     - |
       mkdir -p $HOME/.ssh
-      echo "((thinkcenter-ssh-config))" > $HOME/.ssh/config
-      echo "((thinkcenter-ssh-private))" > $HOME/.ssh/thinkcenter_rsa
-      echo "((thinkcenter-ssh-public))" > $HOME/.ssh/thinkcenter_rsa.pub
+      echo "((thinkcenter_ssh_config))" > $HOME/.ssh/config
+      echo "((thinkcenter_ssh_private))" > $HOME/.ssh/thinkcenter_rsa
+      echo "((thinkcenter_ssh_public))" > $HOME/.ssh/thinkcenter_rsa.pub
       chmod -R 700 $HOME/.ssh
       chmod 644 $HOME/.ssh/thinkcenter_rsa
       chmod 700 $HOME/.ssh/thinkcenter_rsa.pub
       ssh-agent /bin/bash
       ssh-add $HOME/.ssh/thinkcenter_rsa
       ssh-keyscan -t rsa thinkcenter.dev > $HOME/.ssh/known_hosts
-      echo "Listing docker context"
+      
+      echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
-      docker context use remote-thinkcenter
-      echo "Listing currently running containers"
-      docker ps -a
+      docker context use remote-thinkcenter      
+
+      export RUNNING_APP_IMAGE=$(docker ps --format "{{.Image}}" --filter "name=((container_name))" --filter "status=running")      
+      if [[ -n "${RUNNING_APP_IMAGE}" ]];
+        echo "Stopping and removing containers using ${RUNNING_APP_IMAGE} and deleting the image from the local cache"
+        docker stop ((container_name))
+        docker rm ((container_name))
+        docker rmi ${RUNNING_APP_IMAGE}
+      fi
+
+      echo "Loading and starting ((container_name)):((image_version_to_deploy))"
+      docker load --input image/image.tar
+      docker tag $(cat image/digest) ((container_name))
+      docker run ((container_name)):((image_version_to_deploy)) --name=((container_name)) \
+        --label "traefik.enable=true" \
+        --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)" \
+        --label "traefik.http.routers.((container_name)).entrypoints=websecure" \
+        --label "traefik.http.routers.((container_name)).tls=true" \
+        --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
+
       
 
 

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -30,14 +30,7 @@ run:
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter            
       export EXISTING_APP_CONTAINERS_IDS=$(docker ps --format "{{.ID}}" --filter "name=((container_name))")
-    - >
-      if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]];
-      then
-      echo "Stopping and removing existing containers for ((container_name))";
-      docker stop "${EXISTING_APP_CONTAINERS_IDS}";
-      docker rm "${EXISTING_APP_CONTAINERS_IDS}";
-      fi
-    - |
+      if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]]; then echo "Stopping and removing existing containers for ((container_name))"; docker stop "${EXISTING_APP_CONTAINERS_IDS}"; docker rm "${EXISTING_APP_CONTAINERS_IDS}"; fi
       echo "Loading and tagging ((deployable_image_name))"
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -15,9 +15,15 @@ run:
     - -c
     - |
       mkdir -p $HOME/.ssh
-      echo "((thinkcenter-ssh-key))" > $HOME/.ssh/thinkcenter_rsa
-      ssh-add thinkcenter_rsa
-      ssh-keyscan -t rsa thinkcenter.dev >> $HOME/.ssh/known_hosts
+      echo "((thinkcenter-ssh-config))" > $HOME/.ssh/config
+      echo "((thinkcenter-ssh-private))" > $HOME/.ssh/thinkcenter_rsa
+      echo "((thinkcenter-ssh-public))" > $HOME/.ssh/thinkcenter_rsa.pub
+      chmod -R 700 $HOME/.ssh
+      chmod 644 $HOME/.ssh/thinkcenter_rsa
+      chmod 700 $HOME/.ssh/thinkcenter_rsa.pub
+      ssh-agent /bin/bash
+      ssh-add $HOME/.ssh/thinkcenter_rsa
+      ssh-keyscan -t rsa thinkcenter.dev > $HOME/.ssh/known_hosts
       echo "Listing docker context"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -30,12 +30,14 @@ run:
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter            
       export EXISTING_APP_CONTAINERS_IDS=$(docker ps --format "{{.ID}}" --filter "name=((container_name))")
+    - >
       if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]];
       then
-        echo "Stopping and removing existing containers for ((container_name))"
-        docker stop "${EXISTING_APP_CONTAINERS_IDS}"
-        docker rm "${EXISTING_APP_CONTAINERS_IDS}"
+      echo "Stopping and removing existing containers for ((container_name))";
+      docker stop "${EXISTING_APP_CONTAINERS_IDS}";
+      docker rm "${EXISTING_APP_CONTAINERS_IDS}";
       fi
+    - |
       echo "Loading and tagging ((deployable_image_name))"
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -37,10 +37,11 @@ run:
         docker rm ((container_name))
         docker rmi ${RUNNING_APP_IMAGE}
       fi
-      echo "Loading and starting ((deployable_image_name)) with name ((container_name))"
+      echo "Loading and tagging ((deployable_image_name))"
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))
-      docker run ((deployable_image_name)) --name=((container_name)) \
+      echo "Running ((deployable_image_name)) with name ((container_name))"
+      docker run --name=((container_name)) -d ((deployable_image_name)) \
         --label "traefik.enable=true" \
         --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)" \
         --label "traefik.http.routers.((container_name)).entrypoints=websecure" \

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -18,17 +18,17 @@ run:
       echo "((thinkcenter_ssh_config))" > $HOME/.ssh/config
       echo "((thinkcenter_ssh_private))" > $HOME/.ssh/thinkcenter_rsa
       echo "((thinkcenter_ssh_public))" > $HOME/.ssh/thinkcenter_rsa.pub
+      echo "Setting permissions for SSH keys and directories"
       chmod -R 700 $HOME/.ssh
       chmod 600 $HOME/.ssh/thinkcenter_rsa
       chmod 644 $HOME/.ssh/thinkcenter_rsa.pub
+      echo "Adding our SSH key to the agent to communicate with thinkcenter"
       ssh-agent /bin/bash
       ssh-add $HOME/.ssh/thinkcenter_rsa
-      ssh-keyscan thinkcenter.dev > $HOME/.ssh/known_hosts
-      
+      ssh-keyscan thinkcenter.dev > $HOME/.ssh/known_hosts      
       echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter      
-
       export RUNNING_APP_IMAGE=$(docker ps --format "{{.Image}}" --filter "name=((container_name))" --filter "status=running")      
       if [[ -n "${RUNNING_APP_IMAGE}" ]];
       then

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -29,10 +29,10 @@ run:
       echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter            
-      export EXISTING_APP_CONTAINERS_IDS=$(docker ps --format "{{.ID}}" --filter "name=((container_name))" --filter "status=running")
+      export EXISTING_APP_CONTAINERS_IDS=$(docker ps --format "{{.ID}}" --filter "name=((container_name))")
       if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]];
       then
-        echo "Stopping and removing containers using ${RUNNING_APP_IMAGE}"
+        echo "Stopping and removing existing containers for ((container_name))"
         docker stop "${EXISTING_APP_CONTAINERS_IDS}"
         docker rm "${EXISTING_APP_CONTAINERS_IDS}"
       fi
@@ -44,11 +44,13 @@ run:
       docker run 
       --name=((container_name))
       --detach
+      --network=thinknetwork
       --label "traefik.enable=true"
-      --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)"
+      --label "traefik.http.routers.((container_name)).rule=Host(\`((app_url_reverse_proxy))\`)"
       --label "traefik.http.routers.((container_name)).entrypoints=websecure"
       --label "traefik.http.routers.((container_name)).tls=true"
       --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
+      --env "DASHBITS_ENV=production"
       ((deployable_image_name))
 
       

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -10,7 +10,7 @@ inputs:
   - name: image
   
 run:
-  path: sh
+  path: bash
   args: 
     - -c
     - |

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -51,7 +51,7 @@ run:
       --label "traefik.http.routers.((container_name)).tls=true" \
       --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))" \
       --env "DASHBITS_ENV=production" \
-      ((deployable_image_name)) \
+      ((deployable_image_name))
       echo "Done deploying ((deployable_image_name)) with name ((container_name)) !"
 
 

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -15,9 +15,9 @@ run:
     - -c
     - |
       mkdir -p $HOME/.ssh
-      echo "((thinkcenter_ssh_config))" > $HOME/.ssh/config
-      echo "((thinkcenter_ssh_private))" > $HOME/.ssh/thinkcenter_rsa
-      echo "((thinkcenter_ssh_public))" > $HOME/.ssh/thinkcenter_rsa.pub
+      echo "((deploy_docker_thinkcenter_ssh_config))" > $HOME/.ssh/config
+      echo "((deploy_docker_thinkcenter_ssh_private))" > $HOME/.ssh/thinkcenter_rsa
+      echo "((deploy_docker_thinkcenter_ssh_public))" > $HOME/.ssh/thinkcenter_rsa.pub
       echo "Setting permissions for SSH keys and directories"
       chmod -R 700 $HOME/.ssh
       chmod 600 $HOME/.ssh/thinkcenter_rsa
@@ -29,30 +29,30 @@ run:
       echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter            
-      export EXISTING_APP_CONTAINERS_IDS=$(docker ps -a --format "{{.ID}}" --filter "name=((container_name))")
+      export EXISTING_APP_CONTAINERS_IDS=$(docker ps -a --format "{{.ID}}" --filter "name=((deploy_docker_container_name))")
       echo "Existing container IDs ${EXISTING_APP_CONTAINERS_IDS}"
       if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]]; 
       then 
-        echo "Stopping and removing existing containers for ((container_name))"
+        echo "Stopping and removing existing containers for ((deploy_docker_container_name))"
         docker stop "${EXISTING_APP_CONTAINERS_IDS}"
         docker rm "${EXISTING_APP_CONTAINERS_IDS}"
       fi
-      echo "Loading and tagging ((deployable_image_name))"
+      echo "Loading and tagging ((deploy_docker_deployable_image_name))"
       docker load --input image/image.tar
-      docker tag $(cat image/digest) ((deployable_image_name))
-      echo "Running ((deployable_image_name)) with name ((container_name))"
+      docker tag $(cat image/digest) ((deploy_docker_deployable_image_name))
+      echo "Running ((deploy_docker_deployable_image_name)) with name ((deploy_docker_container_name))"
       docker run \
-      --name=((container_name)) \
+      --name=((deploy_docker_container_name)) \
       --detach \
       --network=thinknetwork \
       --label "traefik.enable=true" \
-      --label "traefik.http.routers.((container_name)).rule=Host(\`((app_url_reverse_proxy))\`)" \
-      --label "traefik.http.routers.((container_name)).entrypoints=websecure" \
-      --label "traefik.http.routers.((container_name)).tls=true" \
-      --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))" \
+      --label "traefik.http.routers.((deploy_docker_container_name)).rule=Host(\`((deploy_docker_app_url_reverse_proxy))\`)" \
+      --label "traefik.http.routers.((deploy_docker_container_name)).entrypoints=websecure" \
+      --label "traefik.http.routers.((deploy_docker_container_name)).tls=true" \
+      --label "traefik.http.services.((deploy_docker_container_name)).loadbalancer.server.port=((deploy_docker_app_server_port))" \
       --env "DASHBITS_ENV=production" \
-      ((deployable_image_name))
-      echo "Done deploying ((deployable_image_name)) with name ((container_name)) !"
+      ((deploy_docker_deployable_image_name))
+      echo "Done deploying ((deploy_docker_deployable_image_name)) with name ((deploy_docker_container_name)) !"
 
 
       

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -19,8 +19,8 @@ run:
       echo "((thinkcenter_ssh_private))" > $HOME/.ssh/thinkcenter_rsa
       echo "((thinkcenter_ssh_public))" > $HOME/.ssh/thinkcenter_rsa.pub
       chmod -R 700 $HOME/.ssh
-      chmod 644 $HOME/.ssh/thinkcenter_rsa
-      chmod 700 $HOME/.ssh/thinkcenter_rsa.pub
+      chmod 600 $HOME/.ssh/thinkcenter_rsa
+      chmod 644 $HOME/.ssh/thinkcenter_rsa.pub
       ssh-agent /bin/bash
       ssh-add $HOME/.ssh/thinkcenter_rsa
       ssh-keyscan thinkcenter.dev > $HOME/.ssh/known_hosts

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -31,6 +31,7 @@ run:
 
       export RUNNING_APP_IMAGE=$(docker ps --format "{{.Image}}" --filter "name=((container_name))" --filter "status=running")      
       if [[ -n "${RUNNING_APP_IMAGE}" ]];
+      then
         echo "Stopping and removing containers using ${RUNNING_APP_IMAGE} and deleting the image from the local cache"
         docker stop ((container_name))
         docker rm ((container_name))

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -29,8 +29,14 @@ run:
       echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter            
-      export EXISTING_APP_CONTAINERS_IDS=$(docker ps --format "{{.ID}}" --filter "name=((container_name))")
-      if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]]; then echo "Stopping and removing existing containers for ((container_name))"; docker stop "${EXISTING_APP_CONTAINERS_IDS}"; docker rm "${EXISTING_APP_CONTAINERS_IDS}"; fi
+      export EXISTING_APP_CONTAINERS_IDS=$(docker ps -a --format "{{.ID}}" --filter "name=((container_name))")
+      echo "Existing container IDs ${EXISTING_APP_CONTAINERS_IDS}"
+      if [[ -n "${EXISTING_APP_CONTAINERS_IDS}" ]]; 
+      then 
+        echo "Stopping and removing existing containers for ((container_name))"
+        docker stop "${EXISTING_APP_CONTAINERS_IDS}"
+        docker rm "${EXISTING_APP_CONTAINERS_IDS}"
+      fi
       echo "Loading and tagging ((deployable_image_name))"
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -29,7 +29,7 @@ run:
       echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
       docker context use remote-thinkcenter      
-      export RUNNING_APP_IMAGE=$(docker ps --format "{{.Image}}" --filter "name=((container_name))" --filter "status=running")      
+      export RUNNING_APP_IMAGE=$(docker ps --format "{{.Image}}" --filter "name=((container_name))" --filter "status=running")
       if [[ -n "${RUNNING_APP_IMAGE}" ]];
       then
         echo "Stopping and removing containers using ${RUNNING_APP_IMAGE} and deleting the image from the local cache"
@@ -37,10 +37,10 @@ run:
         docker rm ((container_name))
         docker rmi ${RUNNING_APP_IMAGE}
       fi
-      echo "Loading and starting ((container_name)):((image_version_to_deploy))"
+      echo "Loading and starting ((deployable_image_name)) with name ((container_name))"
       docker load --input image/image.tar
-      docker tag $(cat image/digest) ((container_name))
-      docker run ((container_name)):((image_version_to_deploy)) --name=((container_name)) \
+      docker tag $(cat image/digest) ((deployable_image_name))
+      docker run ((deployable_image_name)) --name=((container_name)) \
         --label "traefik.enable=true" \
         --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)" \
         --label "traefik.http.routers.((container_name)).entrypoints=websecure" \

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -37,6 +37,15 @@ run:
         docker rm ((container_name))
         docker rmi ${RUNNING_APP_IMAGE}
       fi
+      echo "Loading and starting ((container_name)):((image_version_to_deploy))"
+      docker load --input image/image.tar
+      docker tag $(cat image/digest) ((container_name))
+      docker run ((container_name)):((image_version_to_deploy)) --name=((container_name)) \
+        --label "traefik.enable=true" \
+        --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)" \
+        --label "traefik.http.routers.((container_name)).entrypoints=websecure" \
+        --label "traefik.http.routers.((container_name)).tls=true" \
+        --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
 
       
       

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -23,7 +23,7 @@ run:
       chmod 700 $HOME/.ssh/thinkcenter_rsa.pub
       ssh-agent /bin/bash
       ssh-add $HOME/.ssh/thinkcenter_rsa
-      ssh-keyscan -t rsa thinkcenter.dev > $HOME/.ssh/known_hosts
+      ssh-keyscan thinkcenter.dev > $HOME/.ssh/known_hosts
       
       echo "Creating docker context to control the daemon on thinkcenter.dev"
       docker context create remote-thinkcenter --docker "host=ssh://admin@thinkcenter.dev,key=$HOME/.ssh/thinkcenter_rsa"
@@ -37,16 +37,7 @@ run:
         docker rmi ${RUNNING_APP_IMAGE}
       fi
 
-      echo "Loading and starting ((container_name)):((image_version_to_deploy))"
-      docker load --input image/image.tar
-      docker tag $(cat image/digest) ((container_name))
-      docker run ((container_name)):((image_version_to_deploy)) --name=((container_name)) \
-        --label "traefik.enable=true" \
-        --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)" \
-        --label "traefik.http.routers.((container_name)).entrypoints=websecure" \
-        --label "traefik.http.routers.((container_name)).tls=true" \
-        --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
-
+      
       
 
 

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -41,8 +41,8 @@ run:
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))
       echo "Running ((deployable_image_name)) with name ((container_name))"
-    - >
-      docker run 
+    - >+
+      docker run
       --name=((container_name))
       --detach
       --network=thinknetwork

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -41,19 +41,18 @@ run:
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))
       echo "Running ((deployable_image_name)) with name ((container_name))"
-    - >+
-      docker run
-      --name=((container_name))
-      --detach
-      --network=thinknetwork
-      --label "traefik.enable=true"
-      --label "traefik.http.routers.((container_name)).rule=Host(\`((app_url_reverse_proxy))\`)"
-      --label "traefik.http.routers.((container_name)).entrypoints=websecure"
-      --label "traefik.http.routers.((container_name)).tls=true"
-      --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
-      --env "DASHBITS_ENV=production"
-      ((deployable_image_name))
-    - echo "Done deploying ((deployable_image_name)) with name ((container_name)) !"
+      docker run \
+      --name=((container_name)) \
+      --detach \
+      --network=thinknetwork \
+      --label "traefik.enable=true" \
+      --label "traefik.http.routers.((container_name)).rule=Host(\`((app_url_reverse_proxy))\`)" \
+      --label "traefik.http.routers.((container_name)).entrypoints=websecure" \
+      --label "traefik.http.routers.((container_name)).tls=true" \
+      --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))" \
+      --env "DASHBITS_ENV=production" \
+      ((deployable_image_name)) \
+      echo "Done deploying ((deployable_image_name)) with name ((container_name)) !"
 
 
       

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -40,14 +40,16 @@ run:
       docker load --input image/image.tar
       docker tag $(cat image/digest) ((deployable_image_name))
       echo "Running ((deployable_image_name)) with name ((container_name))"
-      docker run --name=((container_name)) \ 
-        --detach \
-        --label "traefik.enable=true" \
-        --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)" \
-        --label "traefik.http.routers.((container_name)).entrypoints=websecure" \
-        --label "traefik.http.routers.((container_name)).tls=true" \
-        --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))" \
-        ((deployable_image_name))
+    - >
+      docker run 
+      --name=((container_name))
+      --detach
+      --label "traefik.enable=true"
+      --label "traefik.http.routers.((container_name)).rule=Host(`((app_url_reverse_proxy))`)"
+      --label "traefik.http.routers.((container_name)).entrypoints=websecure"
+      --label "traefik.http.routers.((container_name)).tls=true"
+      --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
+      ((deployable_image_name))
 
       
       

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -23,7 +23,7 @@ run:
       chmod 600 $HOME/.ssh/thinkcenter_rsa
       chmod 644 $HOME/.ssh/thinkcenter_rsa.pub
       echo "Adding our SSH key to the agent to communicate with thinkcenter"
-      ssh-agent /bin/bash
+      eval $(ssh-agent -s)
       ssh-add $HOME/.ssh/thinkcenter_rsa
       ssh-keyscan thinkcenter.dev > $HOME/.ssh/known_hosts      
       echo "Creating docker context to control the daemon on thinkcenter.dev"

--- a/concourse-ci/tasks/deploy-docker-task.yml
+++ b/concourse-ci/tasks/deploy-docker-task.yml
@@ -53,6 +53,8 @@ run:
       --label "traefik.http.services.((container_name)).loadbalancer.server.port=((app_server_port))"
       --env "DASHBITS_ENV=production"
       ((deployable_image_name))
+    - echo "Done deploying ((deployable_image_name)) with name ((container_name)) !"
+
 
       
       

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -22,9 +22,8 @@ run:
   args: 
     - -c
     - | 
-      apt-get -qq update && apt-get -q install git -y        
-      cd repo
-      export COMMIT_MESSAGE=$(git log -1 --format=%B)
+      apt-get -qq update && apt-get -q install git -y              
+      export COMMIT_MESSAGE=$(cd repo && git log -1 --format=%B)
       echo "Current working directory is"
       pwd
       echo "Commit message is ${COMMIT_MESSAGE}"
@@ -47,10 +46,14 @@ run:
           echo "No relevant keyword found in commit, defaulting to patch update. ((current_version)) -> ${NEW_VERSION}"
           ;;          
       esac
-      
+      echo "${NEW_VERSION}" > version
+
       echo "Updating version in git"      
+      cd repo
+      echo "${NEW_VERSION}" > VERSION
       git config user.email "worker@concourse.thinkcenter.dev"
       git config user.name "Concourse Thinkcenter Worker"
-      git commit -a -m "Version bump ((current_version)) -> ${NEW_VERSION}"
       git tag "v${NEW_VERSION}"
-      echo "${NEW_VERSION}" > version/new_version
+      git commit -a -m "Version bump ((current_version)) -> ${NEW_VERSION}"
+      
+      

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -8,12 +8,14 @@ image_resource:
     tag: 18-slim
 
 caches:
-  - 
+  -  
+
 inputs:
   - name: repo
 
 outputs:
   - name: version
+  - name: repo
 
 run:
   path: sh
@@ -21,7 +23,8 @@ run:
     - -c
     - | 
       apt-get -qq update && apt-get -q install git -y        
-      export COMMIT_MESSAGE=$(cd repo && git log -1 --format=%B)
+      cd repo
+      export COMMIT_MESSAGE=$(git log -1 --format=%B)
       echo "Current working directory is"
       pwd
       echo "Commit message is ${COMMIT_MESSAGE}"
@@ -44,5 +47,8 @@ run:
           echo "No relevant keyword found in commit, defaulting to patch update. ((current_version)) -> ${NEW_VERSION}"
           ;;          
       esac
-      echo "Writing new version to output file"
+      
+      echo "Updating version in git"      
+      git commit -a -m "Version bump ((current_version)) -> ${NEW_VERSION}"
+      git tag "v${NEW_VERSION}"
       echo "${NEW_VERSION}" > version/new_version

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -49,6 +49,8 @@ run:
       esac
       
       echo "Updating version in git"      
+      git config user.email "worker@concourse.thinkcenter.dev"
+      git config user.name "Concourse Thinkcenter Worker"
       git commit -a -m "Version bump ((current_version)) -> ${NEW_VERSION}"
       git tag "v${NEW_VERSION}"
       echo "${NEW_VERSION}" > version/new_version

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -10,8 +10,8 @@ image_resource:
 # Cache directories are relative to the working directory of the task :/
 # See: https://concourse-ci.org/tasks.html#schema.cache
 caches:  
-  - ../../../var/lib/apt/lists
-  - ../../../var/cache/apt
+  - path: ../../../var/lib/apt/lists
+  - path: ../../../var/cache/apt
 
 inputs:
   - name: repo

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -7,8 +7,11 @@ image_resource:
     repository: node
     tag: 18-slim
 
-caches:
-  -  
+# Cache directories are relative to the working directory of the task :/
+# See: https://concourse-ci.org/tasks.html#schema.cache
+caches:  
+  - ../../../var/lib/apt/lists
+  - ../../../var/cache/apt
 
 inputs:
   - name: repo

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -25,38 +25,35 @@ run:
   args: 
     - -c
     - | 
-      apt-get -qq update && apt-get -q install git -y              
+      apt-get -qq update && apt-get -q install git -y
       export COMMIT_MESSAGE=$(cd repo && git log -1 --format=%B)
       echo "Current working directory is"
       pwd
       echo "Commit message is ${COMMIT_MESSAGE}"
-      echo "Current version is ((current_version))"      
-      case "${COMMIT_MESSAGE}" in 
-        fix/* ) 
-          NEW_VERSION=$(npx --yes semver -i patch ((current_version)) )
-          echo "Based on commit message, version gets a patch update. ((current_version)) -> ${NEW_VERSION}"
+      echo "Current version is ((version_calculator_current_version))"
+      case "${COMMIT_MESSAGE}" in
+        fix/* )
+          NEW_VERSION=$(npx --yes semver -i patch ((version_calculator_current_version)) )
+          echo "Based on commit message, version gets a patch update. ((version_calculator_current_version)) -> ${NEW_VERSION}"
           ;;
-        feat/* ) 
-          NEW_VERSION=$(npx --yes semver -i minor ((current_version)) )
-          echo "Based on commit message, version gets a minor update. ((current_version)) -> ${NEW_VERSION}"
+        feat/* )
+          NEW_VERSION=$(npx --yes semver -i minor ((version_calculator_current_version)) )
+          echo "Based on commit message, version gets a minor update. ((version_calculator_current_version)) -> ${NEW_VERSION}"
           ;;
-        breaking/* ) 
-          NEW_VERSION=$(npx --yes semver -i major ((current_version)) )
-          echo "Based on commit message, version gets a major update. ((current_version)) -> ${NEW_VERSION}"
+        breaking/* )
+          NEW_VERSION=$(npx --yes semver -i major ((version_calculator_current_version)) )
+          echo "Based on commit message, version gets a major update. ((version_calculator_current_version)) -> ${NEW_VERSION}"
           ;;
-        *) 
-          NEW_VERSION=$(npx --yes semver -i patch ((current_version)) )
-          echo "No relevant keyword found in commit, defaulting to patch update. ((current_version)) -> ${NEW_VERSION}"
-          ;;          
+        *)
+          NEW_VERSION=$(npx --yes semver -i patch ((version_calculator_current_version)) )
+          echo "No relevant keyword found in commit, defaulting to patch update. ((version_calculator_current_version)) -> ${NEW_VERSION}"
+          ;;
       esac
       echo "${NEW_VERSION}" > version/new_version
-
-      echo "Updating version in git"      
+      echo "Updating version in git"
       cd repo
-      echo "${NEW_VERSION}" > ((version_file_path))
+      echo "${NEW_VERSION}" > ((version_calculator_version_file_path))
       git config user.email "worker@concourse.thinkcenter.dev"
       git config user.name "Concourse Thinkcenter Worker"
       git tag "v${NEW_VERSION}"
-      git commit -a -m "Version bump ((current_version)) -> ${NEW_VERSION}"
-      
-      
+      git commit -a -m "Version bump ((version_calculator_current_version)) -> ${NEW_VERSION}"

--- a/concourse-ci/tasks/version-calculator-task.yml
+++ b/concourse-ci/tasks/version-calculator-task.yml
@@ -46,11 +46,11 @@ run:
           echo "No relevant keyword found in commit, defaulting to patch update. ((current_version)) -> ${NEW_VERSION}"
           ;;          
       esac
-      echo "${NEW_VERSION}" > version
+      echo "${NEW_VERSION}" > version/new_version
 
       echo "Updating version in git"      
       cd repo
-      echo "${NEW_VERSION}" > VERSION
+      echo "${NEW_VERSION}" > ((version_file_path))
       git config user.email "worker@concourse.thinkcenter.dev"
       git config user.name "Concourse Thinkcenter Worker"
       git tag "v${NEW_VERSION}"


### PR DESCRIPTION
## Summary of changes

- Complete the "CD" portion of "CI/CD" by automating the deployment of a docker app in a very non-secure, hard reset and simple kind of way
  - Use docker context with SSH
  - Kill running images (old)
  - Transfer new image to host via `docker load`, tag it appropriately and run it with proper labels so traefik can pick it up
- Complete the semver-ish version calculator so that the version propagates to git & docker tags
- Standardize the naming for task vars by adding a prefix
- Some other stuff I probably forgot about :D 