### PR TITLE
Add renovate workflow + config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,49 @@
+{
+  // Renovate configuration for labrador-maison
+  // https://docs.renovatebot.com/configuration-options/
+
+  // Platform configuration
+  "platform": "github",
+  "timezone": "America/Toronto",
+
+  // Extend recommended base configuration
+  "extends": ["config:recommended"],
+
+  // Unlimited concurrent PRs and branches
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
+
+  // Enable digest pinning for Docker images
+  "docker-compose": {
+    "pinDigests": true
+  },
+
+  // Package rules for automerging and release age delays
+  "packageRules": [
+    {
+      // Automerge minor, patch, pin, and digest updates
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      // Never automerge major updates
+      // Delay major updates by 7 days before proposing
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "minimumReleaseAge": "7 days"
+    }
+  ],
+
+  // Use GitHub platform automerge (via merge button)
+  "platformAutomerge": true,
+
+  // Add labels to all PRs
+  "labels": ["dependencies"],
+
+  // Use semantic commit messages
+  "semanticCommits": true,
+
+  // Disable onboarding since we're providing explicit config
+  "onboarding": false,
+  "requireConfig": "optional"
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,20 @@
+name: Renovate
+
+on:
+  schedule:
+    # Run every Wednesday at 10:00 UTC (05:00 AM EST / 04:00 AM EDT)
+    - cron: '0 10 * * 3'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v44.2.6
+        with:
+          configurationFile: .github/renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
- Renovate workflow runs on a schedule or on demand
- Major updates require human approval
- Minor + Patch updates can be automerged
- Dependencies must have pinned digests (only docker-compose for now, more to come later)
- Depends on a PAT that needs to be generated and set as a secret